### PR TITLE
Python314

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,15 @@ name: wmm ci pipeline
 
 on:
   push:
-    branches: ['*']
+    branches: ['python314']
 
 jobs:
   test:
     runs-on: ubuntu-latest
     continue-on-error: false  # Fail the job if differences exist
+    strategy:
+        matrix:
+            python-version: ['3.11', '3.12', '3.13', '3.14']
 
 
     steps:
@@ -17,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |
@@ -37,15 +40,7 @@ jobs:
         diff -r tests/diff_results_get_all.csv tests/diff_results_get_single.csv
         
 
-    - name: Upload test results
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-results
-        path: |
-          tests/diff_results_get_all.csv
-          tests/diff_results_get_single.csv
-
-    
+   
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     continue-on-error: false  # Fail the job if differences exist
-    strategy:
-        matrix:
-            python-version: ['3.11', '3.12', '3.13', '3.14']
 
 
     steps:
@@ -20,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.14"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: false
     strategy:
       matrix:
         python_version: [ '3.11', '3.12', '3.13', '3.14']

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [ '3.9', '3.10', '3.11', '3.12', '3.13']
+        python_version: [ '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,17 @@
 [project]
 name = "wmm-calculator"
-version = "1.4.3"
+version = "1.4.4"
 description = "WMM Python Module"
 authors = [{name = "Collin Kadlecek", email = "collin.kadlecek@noaa.gov"},
     { name = "Li-Yin Young", email = "liyin.young@noaa.gov" }
     ]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]

--- a/tests/Test_wmm.py
+++ b/tests/Test_wmm.py
@@ -182,15 +182,18 @@ class Test_wmm(unittest.TestCase):
         month = 3
         day = 25
 
+        dt_today = dt.datetime.now()
+        this_year = dt_today.year
+
         year, month, day = fill_timeslot(year, month, day)
 
-        self.assertEqual(year, 2025)
+        self.assertEqual(year, this_year)
         self.assertEqual(month, 3)
         self.assertEqual(day, 25)
 
         year, month, day = fill_timeslot(year, month, day)
 
-        self.assertEqual(year, 2025)
+        self.assertEqual(year, this_year)
         self.assertEqual(month, 3)
 
     def test_setup_empty_time(self):

--- a/tests/Test_wmm.py
+++ b/tests/Test_wmm.py
@@ -1,5 +1,7 @@
 import os.path
 import unittest
+
+import geomaglib.util
 import numpy as np
 import datetime as dt
 
@@ -26,9 +28,12 @@ class Test_wmm(unittest.TestCase):
 
         self.top_dir = os.path.dirname(os.path.dirname(__file__))
         self.wmm_file = os.path.join(self.top_dir, "wmm", "coefs", "WMM.COF")
+        coef = load.load_wmm_coefs(self.wmm_file, nmax=12)
+        self.start_time = coef["epoch"]
 
         self.wmm_testval = os.path.join(self.top_dir, "tests", "WMM2025_TEST_VALUE_TABLE_FOR_REPORT.txt")
         self.get_wmm_testval()
+
 
     def get_wmm_testval(self):
 
@@ -92,10 +97,13 @@ class Test_wmm(unittest.TestCase):
         print("here")
 
 
+        decimal_year = float(self.start_time) + 0.5
+
+
         for nmax in nmax_cases:
             print(f'doing test case {nmax}')
             model = wmm_calc(nmax)
-            model.setup_time(dyear = 2025.5 + 0.1*nmax)
+            model.setup_time(dyear = decimal_year + 0.1*nmax)
             num_elements = sh_loader.calc_sh_degrees_to_num_elems(nmax)
             self.assertEqual(len(model.coef_dict["g"]), num_elements + 1)
             self.assertEqual(nmax, model.nmax)
@@ -108,7 +116,7 @@ class Test_wmm(unittest.TestCase):
             try:
                 model = wmm_calc(nmax)
                 model.setup_max_degree(nmax)
-                model.setup_time(dyear = 2025.5 + 0.1*nmax)
+                model.setup_time(dyear = decimal_year + 0.1*nmax)
             except ValueError as e:
                 self.assertEqual(str(e), f"The degree is not available. Please assign the degree > 0 and degree <= 12.")
 
@@ -118,7 +126,7 @@ class Test_wmm(unittest.TestCase):
                 print(nmax)
                 model = wmm_calc(nmax)
                 model.setup_max_degree(nmax)
-                model.setup_time(dyear = 2025.5 + 0.1*nmax)
+                model.setup_time(dyear = decimal_year + 0.1*nmax)
             except TypeError as e:
                 print(e)
                 self.assertEqual(str(e), f"Please provide nmax with integer type.")
@@ -130,7 +138,10 @@ class Test_wmm(unittest.TestCase):
     def test_setup_dtime_arr(self):
 
         model = wmm_calc()
-        dyears = np.array([2025.5, 2026.6])
+        date1 = float(self.start_time) + 0.66
+        date2 = float(self.start_time) + 0.7
+
+        dyears = np.array([date1, date2])
 
         model.setup_env(self.lats, self.lons, self.alts)
         model.setup_time(dyear=self.dyears)
@@ -142,7 +153,11 @@ class Test_wmm(unittest.TestCase):
     def test_setup_dtime_tuple(self):
 
         model = wmm_calc()
-        dyears = (2025.5, 2026.6)
+        date1 = float(self.start_time) + 2.8
+        date2 = float(self.start_time) + 3.5
+
+
+        dyears = (date1, date2)
 
         dy_arr = utils.to_npFloatarr(dyears)
 
@@ -161,18 +176,18 @@ class Test_wmm(unittest.TestCase):
     def test_setup_strdate(self):
 
         model = wmm_calc()
-        years = np.array([2025, 2026])
+        year1 = int(self.start_time) + 2
+        year2 = int(self.start_time) + 3
+        years = np.array([year1, year2])
         months = np.array([10,11]).astype(int)
         days = np.array([1,2]).astype(int)
 
-
+        dYear1 = geomaglib.util.calc_dec_year(year1, 10, 1)
+        dYear2 = geomaglib.util.calc_dec_year(year2, 11, 2)
+        dyears = [dYear1, dYear2]
 
         model.setup_env(self.lats[:2], self.lons[:2], self.alts[:2])
         model.setup_time(years, months, days)
-
-
-        dyears = [2025.7479452054795, 2026.835616438356]
-
 
         for i in range(len(years)):
             self.assertAlmostEqual(dyears[i], model.dyear[i], places=6)
@@ -220,7 +235,11 @@ class Test_wmm(unittest.TestCase):
 
 
         model = wmm_calc()
-        years = np.array([2025.5, 2026]).astype(int)
+
+        year1 = int(self.start_time) + 1
+        year2 = int(self.start_time) + 3
+
+        years = np.array([year1, year2]).astype(int)
         months = np.array([10, 11]).astype(int)
         days = np.array([1, 2]).astype(int)
         N = 20
@@ -239,7 +258,8 @@ class Test_wmm(unittest.TestCase):
         # the shape of lats is 1
         lons = np.linspace(0,180, N)
         alts = np.linspace(0, 100, N)
-        model.dyear = [2025.5]
+        dYear = float(self.start_time) + 0.55
+        model.dyear = [dYear]
 
         model.setup_env(lats, lons, alts)
         model.setup_time(years, months, days)
@@ -271,7 +291,8 @@ class Test_wmm(unittest.TestCase):
 
         wmm_model = wmm_calc()
         wmm_model.setup_env(self.lats, self.lons, self.alts, msl=False, unit="m")
-        wmm_model.setup_time(2025, 1, 1)
+        iYear = int(self.start_time)
+        wmm_model.setup_time(iYear, 1, 1)
 
         for i in range(len(self.alts)):
             self.assertAlmostEqual(self.alts[i]/1000, wmm_model.alt[i], places=6)
@@ -303,7 +324,8 @@ class Test_wmm(unittest.TestCase):
         lon = np.array([138])
         alt = np.array([77])
 
-        dec_year = np.array([2029.5])
+        dYear = float(self.start_time) + 4.5
+        dec_year = np.array([dYear])
 
         wmm_model = wmm_calc()
 
@@ -381,7 +403,8 @@ class Test_wmm(unittest.TestCase):
         lon = np.array([138])
         alt = np.array([77])
 
-        dec_year = np.array([2029.5])
+        dYear = float(self.start_time) + 4.5
+        dec_year = np.array([dYear])
 
         wmm_model = wmm_calc()
         wmm_model.setup_time(dyear=dec_year)
@@ -401,8 +424,9 @@ class Test_wmm(unittest.TestCase):
     def test_correct_time(self):
 
 
-
-        user_time = np.array([2030.0, 2014.7])
+        date1 = float(self.start_time) + 5.0
+        date2 = float(self.start_time) - 0.3
+        user_time = np.array([date1, date2])
 
         get_err = 0
 
@@ -421,7 +445,8 @@ class Test_wmm(unittest.TestCase):
 
     def test_check_latitude(self):
 
-        user_time = np.array([2025.1])
+        date1 = float(self.start_time) + 0.1
+        user_time = np.array([date1])
         lon, alt = 20, 700
 
         lat = [-90.8, 90.1]
@@ -444,7 +469,8 @@ class Test_wmm(unittest.TestCase):
 
     def test_check_longtitude(self):
 
-        user_time = np.array([2025.1])
+        date1 = float(self.start_time) + 0.1
+        user_time = np.array([date1])
 
         lat = np.array([-18])
         lon = np.array([-180.0, 360.1])
@@ -467,8 +493,9 @@ class Test_wmm(unittest.TestCase):
     @unittest.expectedFailure
     def test_not_setup_env(self):
 
+        date1 = float(self.start_time) + 3.77
         model = wmm_calc()
-        user_time = np.array([2025.1])
+        user_time = np.array([date1])
         model.setup_time(dyear=user_time)
         x = model.get_Bx()
 
@@ -476,7 +503,8 @@ class Test_wmm(unittest.TestCase):
 
     def test_wmm_altitude_warning(self):
 
-        user_time = np.array([2025.1])
+        date1 = float(self.start_time) + 2.778
+        user_time = np.array([date1])
 
         lat = np.array([-18])
         lon = np.array([138])
@@ -501,6 +529,7 @@ class Test_wmm(unittest.TestCase):
 
     def test_get_uncertainty(self):
 
+        date1 = float(self.start_time) + 1.46
         user_time = np.array([2025.1])
 
         lat = np.array([-18, 20, 20])

--- a/wmm/__init__.py
+++ b/wmm/__init__.py
@@ -3,7 +3,7 @@ from .uncertainty import err_model
 
 __all__ = ['wmm_calc', 'wmm_elements']
 
-__version__ = "1.3.1"
+__version__ = "1.4.4"
 
 
 


### PR DESCRIPTION
- Updated the tags for announcing users that the wmm package is compatible with python 3.11 to 3.14
- Updated the version number in pyproject.toml and __init__.py to 1.4.4
- To make it easier for maintaining in the future, set up the time based on current year. For example, wmm is renewed every 5 years. If we hard coded the date as 2025.*, it will not pass the unit test when wmm2030 is released.