### PR TITLE
Further broadcast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,15 @@ name: wmm ci pipeline
 
 on:
   push:
-    branches: ['*']
+    branches: ['python314']
 
 jobs:
   test:
     runs-on: ubuntu-latest
     continue-on-error: false  # Fail the job if differences exist
+    strategy:
+        matrix:
+            python-version: ['3.11', '3.12', '3.13', '3.14']
 
 
     steps:
@@ -17,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |
@@ -37,15 +40,7 @@ jobs:
         diff -r tests/diff_results_get_all.csv tests/diff_results_get_single.csv
         
 
-    - name: Upload test results
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-results
-        path: |
-          tests/diff_results_get_all.csv
-          tests/diff_results_get_single.csv
-
-    
+   
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: wmm ci pipeline
 
 on:
   push:
-    branches: ['python314']
+    branches: ['further_broadcast']
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     continue-on-error: false  # Fail the job if differences exist
-    strategy:
-        matrix:
-            python-version: ['3.11', '3.12', '3.13', '3.14']
 
 
     steps:
@@ -20,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.14"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: false
     strategy:
       matrix:
         python_version: [ '3.11', '3.12', '3.13', '3.14']

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [ '3.9', '3.10', '3.11', '3.12', '3.13']
+        python_version: [ '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,17 @@
 [project]
 name = "wmm-calculator"
-version = "1.4.3"
+version = "1.4.4"
 description = "WMM Python Module"
 authors = [{name = "Collin Kadlecek", email = "collin.kadlecek@noaa.gov"},
     { name = "Li-Yin Young", email = "liyin.young@noaa.gov" }
     ]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
+python_files = test_*.py Test_*.py
 markers =
     smoke: Quick smoke tests
-

--- a/tests/SystemTest.py
+++ b/tests/SystemTest.py
@@ -6,10 +6,13 @@ import numpy as np
 
 from wmm.build import wmm_calc
 
-from tests.est_diff import estimate
+from est_diff import estimate
 
 
 def write_diff_results(file_path, inputs, true_v, pred_v):
+    """
+    Write th results that are different with the test values into csv file for statistic analysis
+    """
 
     results_str = (",").join(inputs)
 
@@ -24,6 +27,9 @@ def write_diff_results(file_path, inputs, true_v, pred_v):
 
 
 def check_base_results(res_map, index, lat, lon, alt, dyear, dec, inc, h, x, y, z, f, tol, folder_path):
+    """
+    Verify the results for non sv magnetic elements
+    """
 
     inputs = [str(dyear), str(lat), str(lon), str(alt)]
 
@@ -53,6 +59,9 @@ def check_base_results(res_map, index, lat, lon, alt, dyear, dec, inc, h, x, y, 
 
 
 def check_sv_results(res_map, index, lat, lon, alt, dyear, dec, inc, h, x, y, z, f, tol, folder_path):
+    """
+    Verify the sv results
+    """
 
     inputs = [str(dyear), str(lat), str(lon), str(alt)]
     if (fabs(res_map["dx"][index] - x) > tol):
@@ -79,6 +88,9 @@ def check_sv_results(res_map, index, lat, lon, alt, dyear, dec, inc, h, x, y, z,
 
 
 def refer_testValues(testval_filename: str) -> tuple[np.array, np.array, np.array, np.array]:
+    """
+    Get the values from test value files
+    """
 
     dyears, alts, lats, lons = [], [], [], []
     with open(testval_filename, "r") as fp:
@@ -107,6 +119,9 @@ def refer_testValues(testval_filename: str) -> tuple[np.array, np.array, np.arra
 
 
 def compare_all_results(testval_filename, dyears, lats, lons, alts, res_folder, reserr_folder):
+    """
+    Verify the results obtained from get_all()
+    """
 
     wmm_model = wmm_calc()
 
@@ -136,6 +151,9 @@ def compare_all_results(testval_filename, dyears, lats, lons, alts, res_folder, 
                 index += 1
 
 def get_single_results(wmm_model: wmm_calc) -> dict:
+    """
+    Test get each magnetic element individually.
+    """
 
     map = {}
 
@@ -189,6 +207,12 @@ def compare_single_results(testval_filename, dyears, lats, lons, alts, res_folde
 
 
 def main():
+    """
+    Verify its scientific accuracy by comparing the results obtained from the WMM Python API.
+    To verify the get_all(), pass the all to -r
+    To verify the outputs of getting single elements like get_Bx(), pass the single to -r
+    The statistic results will be saved in diff_results.csv in the same folder
+    """
     testval_filename = "WMM2025_FINAL_TEST_VALUES_HIGHPREC.txt"
 
     parser = argparse.ArgumentParser(description="scitific tests for WMM Python api")
@@ -223,9 +247,11 @@ def main():
     dyears, lats, lons, alts = refer_testValues(testval_path)
 
     if args.results_type == "all":
+        # Test get_all()
         out_filename = out_filename_all
         compare_all_results(testval_path, dyears, lats, lons, alts, res_folder, reserr_folder)
     elif args.results_type == "single":
+        # Test the outputs of getting single elements like get_Bx()
         out_filename = out_filename_single
         compare_single_results(testval_path, dyears, lats, lons, alts, res_folder, reserr_folder)
     else:

--- a/tests/SystemTest.py
+++ b/tests/SystemTest.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from wmm.build import wmm_calc
 
-from est_diff import estimate
+from tests.est_diff import estimate
 
 
 def write_diff_results(file_path, inputs, true_v, pred_v):

--- a/tests/Test_wmm.py
+++ b/tests/Test_wmm.py
@@ -182,15 +182,18 @@ class Test_wmm(unittest.TestCase):
         month = 3
         day = 25
 
+        dt_today = dt.datetime.now()
+        this_year = dt_today.year
+
         year, month, day = fill_timeslot(year, month, day)
 
-        self.assertEqual(year, 2025)
+        self.assertEqual(year, this_year)
         self.assertEqual(month, 3)
         self.assertEqual(day, 25)
 
         year, month, day = fill_timeslot(year, month, day)
 
-        self.assertEqual(year, 2025)
+        self.assertEqual(year, this_year)
         self.assertEqual(month, 3)
 
     def test_setup_empty_time(self):

--- a/tests/Test_wmm.py
+++ b/tests/Test_wmm.py
@@ -11,6 +11,7 @@ from geomaglib import util, sh_loader
 from wmm import load, utils
 from wmm import wmm_calc
 from wmm.build import fill_timeslot
+from wmm import uncertainty
 
 
 
@@ -90,8 +91,10 @@ class Test_wmm(unittest.TestCase):
         self.assertEqual(len(coef["g"]), num_elems + 1)
 
     def test_setup_max_degree(self):
-
-
+        """
+        Check whether setup_max_degree() can allow users to set up the max degree. When the input
+        is out of range or have invalid type, it should return error to users.
+        """
 
         nmax_cases = [1, 5, 10, 11]
         print("here")
@@ -108,7 +111,6 @@ class Test_wmm(unittest.TestCase):
             self.assertEqual(len(model.coef_dict["g"]), num_elements + 1)
             self.assertEqual(nmax, model.nmax)
             model.setup_env(lat = 5, lon = 5, alt = 0)
-            print(f"Get_all output of nmax = {nmax}",model.get_all())
 
 
         nmax_cases = [0, 13, 14]
@@ -131,11 +133,10 @@ class Test_wmm(unittest.TestCase):
                 print(e)
                 self.assertEqual(str(e), f"Please provide nmax with integer type.")
 
-
-
-
-
     def test_setup_dtime_arr(self):
+        """
+        Test users can use setup_time() with dyear .
+        """
 
         model = wmm_calc()
         date1 = float(self.start_time) + 0.66
@@ -151,6 +152,9 @@ class Test_wmm(unittest.TestCase):
 
 
     def test_setup_dtime_tuple(self):
+        """
+        Test whether uesers can uset setup_time() with dyear in tuple.
+        """
 
         model = wmm_calc()
         date1 = float(self.start_time) + 2.8
@@ -174,6 +178,9 @@ class Test_wmm(unittest.TestCase):
             self.assertAlmostEqual(dyears[i], model.dyear[i], places=1)
 
     def test_setup_strdate(self):
+        """
+        Test users can pass year, month and day in array type to setup_time()
+        """
 
         model = wmm_calc()
         year1 = int(self.start_time) + 2
@@ -193,6 +200,9 @@ class Test_wmm(unittest.TestCase):
             self.assertAlmostEqual(dyears[i], model.dyear[i], places=6)
 
     def test_fill_timeslot(self):
+        """
+        When user miss either one of the variables, it should use the current time value as default
+        """
         year = None
         month = 3
         day = 25
@@ -212,7 +222,9 @@ class Test_wmm(unittest.TestCase):
         self.assertEqual(month, 3)
 
     def test_setup_empty_time(self):
-
+        """
+        When users doesn't pass any time variable to setup_time(), it should use the current time as default.
+        """
         model = wmm_calc()
         # model.setup_time()
 
@@ -232,6 +244,9 @@ class Test_wmm(unittest.TestCase):
 
 
     def test_broadcast(self):
+        """
+        Test whether the model can broadcast each of coordinates(lat, lon and alt) to the same shape.
+        """
 
 
         model = wmm_calc()
@@ -252,6 +267,8 @@ class Test_wmm(unittest.TestCase):
         model.setup_env(lats, lons, alts)
         model.setup_time(years, months, days)
 
+
+
         self.assertEqual(len(model.lat), N)
         self.assertEqual(len(model.lon), N)
 
@@ -259,23 +276,39 @@ class Test_wmm(unittest.TestCase):
         lons = np.linspace(0,180, N)
         alts = np.linspace(0, 100, N)
         dYear = float(self.start_time) + 0.55
-        model.dyear = [dYear]
+        model.dyear = [2025.5]
 
         model.setup_env(lats, lons, alts)
         model.setup_time(years, months, days)
-
         self.assertEqual(len(model.lat), N)
         self.assertEqual(len(model.lon), N)
 
-    def test_setup_geod_to_geoc_lat(self):
+        # When year, month, day and coordinates has different shape, and year, month and day shape is not 1
+        wmm = wmm_calc()
+        wmm.setup_env(lats, lons, alts)
+        try:
 
+            wmm.setup_time(years, months, days)
+        except ValueError as e:
+            self.assertEqual(str(e), f"The input time and space vectors have different sizes of time size: {len(years)}, "
+                                     f"position sizes: ({len(lats)}, {len(lons)}, {len(alts)}), input scalars, or vectors of matching length")
+
+
+
+
+
+        #except ValueError as e:
+        #    print(str(e))
+
+
+    def test_setup_geod_to_geoc_lat(self):
+        """
+        Test the covertion of geodetic to geocentric can be done correctly when it is called by setup_env()
+        """
 
 
         alt_true = util.alt_to_ellipsoid_height(self.alts, self.lats, self.lons)
         r, theta = util.geod_to_geoc_lat(self.lats, alt_true)
-
-
-
 
         wmm_model = wmm_calc()
         wmm_model.setup_env(self.lats, self.lons, self.alts, msl=False)
@@ -288,28 +321,26 @@ class Test_wmm(unittest.TestCase):
 
 
     def test_to_km(self):
+        """
+        Test to_km() function
+        """
 
         wmm_model = wmm_calc()
-        wmm_model.setup_env(self.lats, self.lons, self.alts, msl=False, unit="m")
-        iYear = int(self.start_time)
-        wmm_model.setup_time(iYear, 1, 1)
+        wmm_alts = wmm_model.to_km(np.array(self.alts), unit="m")
 
         for i in range(len(self.alts)):
-            self.assertAlmostEqual(self.alts[i]/1000, wmm_model.alt[i], places=6)
-
-
-
-
+            self.assertAlmostEqual(self.alts[i]/1000, wmm_alts[i], places=6)
 
     def test_forward_base(self):
+        """
+        Test forward_base() can return the correct Bx, By and Bz in geodetic
+        """
 
 
         wmm_model = wmm_calc()
 
         wmm_model.setup_time(dyear=self.dyears)
         wmm_model.setup_env(self.lats, self.lons, self.alts, msl=False)
-
-
 
         Bx, By, Bz = wmm_model.forward_base()
 
@@ -318,7 +349,11 @@ class Test_wmm(unittest.TestCase):
             self.assertAlmostEqual(By[i], self.By[i], delta=0.05)
             self.assertAlmostEqual(Bz[i], self.Bz[i], delta=0.05)
 
-    def test_setup_sv(self):
+    def test_get_sv(self):
+
+        """
+        Test users can get sv values by calling forward_sv()
+        """
 
         lat = np.array([-18])
         lon = np.array([138])
@@ -385,6 +420,11 @@ class Test_wmm(unittest.TestCase):
 
     def test_inherit_GeomagElements(self):
 
+        """
+        wmm_element class inherit magmath.GeomagElements class from geomaglib.
+        The test is to check whether it can computing ddec and dinc correctly by using magmath.GeomagElements
+        """
+
 
         wmm_model = wmm_calc()
 
@@ -399,6 +439,9 @@ class Test_wmm(unittest.TestCase):
             self.assertAlmostEqual(map["dinc"][i] , self.dBinc[i], delta=0.05)
 
     def test_reset_env(self):
+        """
+        When users only call wmm class once, it should allow users to reset the lat, lon or alt when users call the function again
+        """
         lat = np.array([-18])
         lon = np.array([138])
         alt = np.array([77])
@@ -409,8 +452,6 @@ class Test_wmm(unittest.TestCase):
         wmm_model = wmm_calc()
         wmm_model.setup_time(dyear=dec_year)
         wmm_model.setup_env(lat, lon, alt, msl=False)
-
-
 
         lat1 = np.array([-19])
         wmm_model.setup_time(dyear=dec_year)
@@ -423,6 +464,9 @@ class Test_wmm(unittest.TestCase):
 
     def test_correct_time(self):
 
+        """
+        Test whether it can verify users provide the valid time for the model.
+        """
 
         date1 = float(self.start_time) + 5.0
         date2 = float(self.start_time) - 0.3
@@ -444,6 +488,9 @@ class Test_wmm(unittest.TestCase):
 
 
     def test_check_latitude(self):
+        """
+        Test whether it can verify users provide the valid latitude.
+        """
 
         date1 = float(self.start_time) + 0.1
         user_time = np.array([date1])
@@ -468,6 +515,9 @@ class Test_wmm(unittest.TestCase):
 
 
     def test_check_longtitude(self):
+        """
+        Test whether it can verify users provide the valid longitude.
+        """
 
         date1 = float(self.start_time) + 0.1
         user_time = np.array([date1])
@@ -490,18 +540,26 @@ class Test_wmm(unittest.TestCase):
         self.assertEqual(get_err, 2)
 
 
-    @unittest.expectedFailure
+    #@unittest.expectedFailure
     def test_not_setup_env(self):
 
         date1 = float(self.start_time) + 3.77
         model = wmm_calc()
         user_time = np.array([date1])
         model.setup_time(dyear=user_time)
-        x = model.get_Bx()
+
+        try:
+            x = model.get_Bx()
+        except TypeError as e:
+            self.assertEqual(str(e), "Coordinates haven't set up yet. Please use setup_env() to set up coordinates first.")
+
 
 
 
     def test_wmm_altitude_warning(self):
+        """
+        It should  return Milspec warning when altitude is < -1 or altitude > 1900 km
+        """
 
         date1 = float(self.start_time) + 2.778
         user_time = np.array([date1])
@@ -540,51 +598,11 @@ class Test_wmm(unittest.TestCase):
         model.setup_time(dyear=user_time)
         model.setup_env(lat, lon, alt)
 
-        print(model.get_uncertainty())
+        uncert_map = model.get_uncertainty()
 
-
-
-
-    def test_readme1(self):
-
-        model = wmm_calc()
-        lat = [80.,  0., 80.]
-        lon = [  0., 120.,   0.]
-        alt = [0., 0., 0.]
-
-        #year = [2025, 2026]
-        #month = [12, 1]
-        #day = [6, 15]
-        dyear = [2025.,  2025.,  2027.5]
-
-        # set up time
-        #model.setup_time(year, month, day)
-        model.setup_time(dyear=dyear)
-        # set up the coordinates
-        model.setup_env(lat, lon, alt)
-
-        print(model.get_uncertainty())
-
-    def test_readme2(self):
-
-        model = wmm_calc()
-        lat = [23.35, 24.5]
-        lon = [40, 45]
-        alt = [21, 21]
-
-        year = [2025, 2026]
-        month = [12, 1]
-        day = [6, 15]
-
-        # set up time
-        model.setup_time(year, month, day)
-        # set up the coordinates
-        model.setup_env(lat, lon, alt)
-
-        print(model.get_all())
-        print(model.get_uncertainty())
-
-
+        self.assertTrue(isinstance(uncert_map, dict))
+        for key, value in uncert_map.items():
+            self.assertIsNotNone(value)
 
 
 

--- a/tests/Test_wmm.py
+++ b/tests/Test_wmm.py
@@ -1,11 +1,12 @@
 import os.path
+import random
 import unittest
 
 import geomaglib.util
 import numpy as np
 import datetime as dt
 
-
+import pytest
 from geomaglib import util, sh_loader
 
 from wmm import load, utils
@@ -242,21 +243,8 @@ class Test_wmm(unittest.TestCase):
 
         self.assertEqual(dyear, model.dyear)
 
-
-    def test_broadcast(self):
-        """
-        Test whether the model can broadcast each of coordinates(lat, lon and alt) to the same shape.
-        """
-
-
+    def test_broadcast_when_two_array_is_size_one(self):
         model = wmm_calc()
-
-        year1 = int(self.start_time) + 1
-        year2 = int(self.start_time) + 3
-
-        years = np.array([year1, year2]).astype(int)
-        months = np.array([10, 11]).astype(int)
-        days = np.array([1, 2]).astype(int)
         N = 20
 
         # the shape of lats and lons is 1
@@ -265,40 +253,141 @@ class Test_wmm(unittest.TestCase):
         alts = np.linspace(0, 100, N)
 
         model.setup_env(lats, lons, alts)
-        model.setup_time(years, months, days)
-
-
 
         self.assertEqual(len(model.lat), N)
         self.assertEqual(len(model.lon), N)
+    def test_broadcast_when_one_array_is_size_one(self):
+        """
+        Test whether the model can broadcast each of coordinates(lat, lon and alt) to the same shape.
+        """
 
+        model = wmm_calc()
         # the shape of lats is 1
+        lats = [10]
+        N = 20
         lons = np.linspace(0,180, N)
         alts = np.linspace(0, 100, N)
         dYear = float(self.start_time) + 0.55
-        model.dyear = [2025.5]
 
         model.setup_env(lats, lons, alts)
-        model.setup_time(years, months, days)
         self.assertEqual(len(model.lat), N)
         self.assertEqual(len(model.lon), N)
 
+        # When latitude is float type
+        lats = 10
+        model.setup_env(lats, lons, alts)
+
+        self.assertEqual(len(model.lat), N)
+        self.assertEqual(len(model.lon), N)
+
+    def test_scalar_time_input(self):
+        """
+        It should convert scalar inputs into nu,py array
+        """
+
+        model = wmm_calc()
+        model.setup_time(dyear=float(self.start_time) + 0.5)
+
+        self.assertEqual(type(model.dyear), np.ndarray)
+
+        year = int(self.start_time)
+        month = 11
+        day = 25
+
+        model = wmm_calc()
+        model.setup_time(year, month, day)
+        self.assertEqual(type(model.dyear), np.ndarray)
+
+    def test_scalar_env_input(self):
+
+        model = wmm_calc()
+        lat, lon, alt = 25, 101, 30
+        model.setup_env(lat, lon, alt)
+
+        self.assertEqual(type(model.lat), np.ndarray)
+        self.assertEqual(type(model.lon), np.ndarray)
+        self.assertEqual(type(model.alt), np.ndarray)
+
+
+
+    def test_check_time_ymd_size(self):
+
+        M = 10
+        years = [int(self.start_time) for _ in range(M)]
+        months = [random.randint(1, 12) for _ in range(2)]
+        days = [random.randint(1, 28) for _ in range(M)]
+
+
+        model = wmm_calc()
+        year_size, month_size, day_size = np.size(years), np.size(months), np.size(days)
+        sizes = np.array([year_size, month_size, day_size])
+
+
+        with pytest.raises(ValueError) as excinfo:
+             model.setup_time(years, months, days)
+
+        assert (f"The input position (year,month,day) have different shapes{sizes}. "
+                f"Input dates must have the same shape or 1 "
+                f"(i.e. valid combinations for input lengths are (10,10,10) or (10,10,1))") in str(excinfo.value)
+
+
+    def test_return_error_when_time_coordinates_has_different_shape(self):
         # When year, month, day and coordinates has different shape, and year, month and day shape is not 1
+
+        N = 20
+        lats = [random.uniform(-45, 45) for i in range(N)]
+        lons = [random.uniform(150, -150) for i in range(N)]
+        alts = [random.uniform(1, 28) for i in range(N)]
+
+        M = 2
+        years = [int(self.start_time) for i in range(M)]
+        months = [random.randint(1, 12) for i in range(M)]
+        days = [random.randint(1, 28) for i in range(M)]
+
         wmm = wmm_calc()
         wmm.setup_env(lats, lons, alts)
-        try:
-
-            wmm.setup_time(years, months, days)
-        except ValueError as e:
-            self.assertEqual(str(e), f"The input time and space vectors have different sizes of time size: {len(years)}, "
-                                     f"position sizes: ({len(lats)}, {len(lons)}, {len(alts)}), input scalars, or vectors of matching length")
+        wmm.setup_time(years, months, days)
 
 
+        with pytest.raises(ValueError) as excinfo:
+            wmm.get_all()
+
+        assert (f"Broadcast error: Get time size: {len(years)}, Get position size: (lat, lon, alt) = {(len(lats),len(lons),len(alts))}. "
+                f"Please input scalars, single array for one parameter or vectors of matching length") in str(excinfo.value)
 
 
 
-        #except ValueError as e:
-        #    print(str(e))
+
+
+    def test_users_reset_the_coordinates_which_is_not_matched_time_inputs(self):
+
+        N = 10
+        lats = [random.uniform(-45, 45) for i in range(N)]
+        lons = [random.uniform(150, -150) for i in range(N)]
+        alts = [random.uniform(1, 28) for i in range(N)]
+
+        M = 10
+        years = [int(self.start_time) for i in range(M)]
+        months = [random.randint(1, 12) for i in range(M)]
+        days = [random.randint(1, 28) for i in range(M)]
+
+        wmm = wmm_calc()
+        wmm.setup_time(years, months, days)
+        wmm.setup_env(lats, lons, alts)
+
+        for N in range(11, 15):
+            lats = [random.uniform(-45, 45) for i in range(N)]
+            lons = [random.uniform(150, -150) for i in range(N)]
+            alts = [random.uniform(1, 28) for i in range(N)]
+
+            try:
+                wmm.setup_env(lats, lons, alts)
+            except ValueError as e:
+                self.assertEqual(str(e),
+                                 f"The input time and space vectors have different sizes of time size: {len(years)}, "
+                                 f"position sizes: ({len(lats)}, {len(lons)}, {len(alts)}), input scalars, or vectors of matching length")
+
+
 
 
     def test_setup_geod_to_geoc_lat(self):

--- a/tests/Test_wmm.py
+++ b/tests/Test_wmm.py
@@ -1,5 +1,7 @@
 import os.path
 import unittest
+
+import geomaglib.util
 import numpy as np
 import datetime as dt
 
@@ -26,9 +28,12 @@ class Test_wmm(unittest.TestCase):
 
         self.top_dir = os.path.dirname(os.path.dirname(__file__))
         self.wmm_file = os.path.join(self.top_dir, "wmm", "coefs", "WMM.COF")
+        coef = load.load_wmm_coefs(self.wmm_file, nmax=12)
+        self.start_time = coef["epoch"]
 
         self.wmm_testval = os.path.join(self.top_dir, "tests", "WMM2025_TEST_VALUE_TABLE_FOR_REPORT.txt")
         self.get_wmm_testval()
+
 
     def get_wmm_testval(self):
 
@@ -92,10 +97,13 @@ class Test_wmm(unittest.TestCase):
         print("here")
 
 
+        decimal_year = float(self.start_time) + 0.5
+
+
         for nmax in nmax_cases:
             print(f'doing test case {nmax}')
             model = wmm_calc(nmax)
-            model.setup_time(dyear = 2025.5 + 0.1*nmax)
+            model.setup_time(dyear = decimal_year + 0.1*nmax)
             num_elements = sh_loader.calc_sh_degrees_to_num_elems(nmax)
             self.assertEqual(len(model.coef_dict["g"]), num_elements + 1)
             self.assertEqual(nmax, model.nmax)
@@ -108,7 +116,7 @@ class Test_wmm(unittest.TestCase):
             try:
                 model = wmm_calc(nmax)
                 model.setup_max_degree(nmax)
-                model.setup_time(dyear = 2025.5 + 0.1*nmax)
+                model.setup_time(dyear = decimal_year + 0.1*nmax)
             except ValueError as e:
                 self.assertEqual(str(e), f"The degree is not available. Please assign the degree > 0 and degree <= 12.")
 
@@ -118,7 +126,7 @@ class Test_wmm(unittest.TestCase):
                 print(nmax)
                 model = wmm_calc(nmax)
                 model.setup_max_degree(nmax)
-                model.setup_time(dyear = 2025.5 + 0.1*nmax)
+                model.setup_time(dyear = decimal_year + 0.1*nmax)
             except TypeError as e:
                 print(e)
                 self.assertEqual(str(e), f"Please provide nmax with integer type.")
@@ -130,7 +138,10 @@ class Test_wmm(unittest.TestCase):
     def test_setup_dtime_arr(self):
 
         model = wmm_calc()
-        dyears = np.array([2025.5, 2026.6])
+        date1 = float(self.start_time) + 0.66
+        date2 = float(self.start_time) + 0.7
+
+        dyears = np.array([date1, date2])
 
         model.setup_env(self.lats, self.lons, self.alts)
         model.setup_time(dyear=self.dyears)
@@ -142,7 +153,11 @@ class Test_wmm(unittest.TestCase):
     def test_setup_dtime_tuple(self):
 
         model = wmm_calc()
-        dyears = (2025.5, 2026.6)
+        date1 = float(self.start_time) + 2.8
+        date2 = float(self.start_time) + 3.5
+
+
+        dyears = (date1, date2)
 
         dy_arr = utils.to_npFloatarr(dyears)
 
@@ -161,18 +176,18 @@ class Test_wmm(unittest.TestCase):
     def test_setup_strdate(self):
 
         model = wmm_calc()
-        years = np.array([2025, 2026])
+        year1 = int(self.start_time) + 2
+        year2 = int(self.start_time) + 3
+        years = np.array([year1, year2])
         months = np.array([10,11]).astype(int)
         days = np.array([1,2]).astype(int)
 
-
+        dYear1 = geomaglib.util.calc_dec_year(year1, 10, 1)
+        dYear2 = geomaglib.util.calc_dec_year(year2, 11, 2)
+        dyears = [dYear1, dYear2]
 
         model.setup_env(self.lats[:2], self.lons[:2], self.alts[:2])
         model.setup_time(years, months, days)
-
-
-        dyears = [2025.7479452054795, 2026.835616438356]
-
 
         for i in range(len(years)):
             self.assertAlmostEqual(dyears[i], model.dyear[i], places=6)
@@ -220,7 +235,11 @@ class Test_wmm(unittest.TestCase):
 
 
         model = wmm_calc()
-        years = np.array([2025.5, 2026]).astype(int)
+
+        year1 = int(self.start_time) + 1
+        year2 = int(self.start_time) + 3
+
+        years = np.array([year1, year2]).astype(int)
         months = np.array([10, 11]).astype(int)
         days = np.array([1, 2]).astype(int)
         N = 20
@@ -239,7 +258,8 @@ class Test_wmm(unittest.TestCase):
         # the shape of lats is 1
         lons = np.linspace(0,180, N)
         alts = np.linspace(0, 100, N)
-        model.dyear = [2025.5]
+        dYear = float(self.start_time) + 0.55
+        model.dyear = [dYear]
 
         model.setup_env(lats, lons, alts)
         model.setup_time(years, months, days)
@@ -271,7 +291,8 @@ class Test_wmm(unittest.TestCase):
 
         wmm_model = wmm_calc()
         wmm_model.setup_env(self.lats, self.lons, self.alts, msl=False, unit="m")
-        wmm_model.setup_time(2025, 1, 1)
+        iYear = int(self.start_time)
+        wmm_model.setup_time(iYear, 1, 1)
 
         for i in range(len(self.alts)):
             self.assertAlmostEqual(self.alts[i]/1000, wmm_model.alt[i], places=6)
@@ -303,7 +324,8 @@ class Test_wmm(unittest.TestCase):
         lon = np.array([138])
         alt = np.array([77])
 
-        dec_year = np.array([2029.5])
+        dYear = float(self.start_time) + 4.5
+        dec_year = np.array([dYear])
 
         wmm_model = wmm_calc()
 
@@ -381,7 +403,8 @@ class Test_wmm(unittest.TestCase):
         lon = np.array([138])
         alt = np.array([77])
 
-        dec_year = np.array([2029.5])
+        dYear = float(self.start_time) + 4.5
+        dec_year = np.array([dYear])
 
         wmm_model = wmm_calc()
         wmm_model.setup_time(dyear=dec_year)
@@ -401,8 +424,9 @@ class Test_wmm(unittest.TestCase):
     def test_correct_time(self):
 
 
-
-        user_time = np.array([2030.0, 2014.7])
+        date1 = float(self.start_time) + 5.0
+        date2 = float(self.start_time) - 0.3
+        user_time = np.array([date1, date2])
 
         get_err = 0
 
@@ -421,7 +445,8 @@ class Test_wmm(unittest.TestCase):
 
     def test_check_latitude(self):
 
-        user_time = np.array([2025.1])
+        date1 = float(self.start_time) + 0.1
+        user_time = np.array([date1])
         lon, alt = 20, 700
 
         lat = [-90.8, 90.1]
@@ -444,7 +469,8 @@ class Test_wmm(unittest.TestCase):
 
     def test_check_longtitude(self):
 
-        user_time = np.array([2025.1])
+        date1 = float(self.start_time) + 0.1
+        user_time = np.array([date1])
 
         lat = np.array([-18])
         lon = np.array([-180.0, 360.1])
@@ -467,8 +493,9 @@ class Test_wmm(unittest.TestCase):
     @unittest.expectedFailure
     def test_not_setup_env(self):
 
+        date1 = float(self.start_time) + 3.77
         model = wmm_calc()
-        user_time = np.array([2025.1])
+        user_time = np.array([date1])
         model.setup_time(dyear=user_time)
         x = model.get_Bx()
 
@@ -476,7 +503,8 @@ class Test_wmm(unittest.TestCase):
 
     def test_wmm_altitude_warning(self):
 
-        user_time = np.array([2025.1])
+        date1 = float(self.start_time) + 2.778
+        user_time = np.array([date1])
 
         lat = np.array([-18])
         lon = np.array([138])
@@ -501,6 +529,7 @@ class Test_wmm(unittest.TestCase):
 
     def test_get_uncertainty(self):
 
+        date1 = float(self.start_time) + 1.46
         user_time = np.array([2025.1])
 
         lat = np.array([-18, 20, 20])

--- a/tests/est_diff.py
+++ b/tests/est_diff.py
@@ -32,6 +32,7 @@ def estimate(file_path: str, out_fp: TextIO, mag_comp: str, tol: float):
     out_fp.write(f"{mag_comp},{round(ave,6)},{round(max_diff,6)},{round(min_diff,6)}\n")
 
 
+
 def main():
 
     diff_res_folder = "results"
@@ -65,6 +66,8 @@ def main():
 
         if os.path.exists(file_path):
             estimate(file_path, fp, magsv_component[i], tol)
+
+
 
 
     fp.close()

--- a/tests/test_vec.py
+++ b/tests/test_vec.py
@@ -429,6 +429,11 @@ def test_setup_max_degree_w_env():
         #     self.assertEqual(str(e), f"The degree is not available. Please assign the degree > 0 and degree <= 12.")
 
 
+@pytest.mark.parametrize("which_case", range(0, 11))
+def test_vector_cases(which_case):
+    vector_test_cases(which_case)
+
+
 
 
 def main():

--- a/wmm/__init__.py
+++ b/wmm/__init__.py
@@ -3,7 +3,7 @@ from .uncertainty import err_model
 
 __all__ = ['wmm_calc', 'wmm_elements']
 
-__version__ = "1.3.1"
+__version__ = "1.4.4"
 
 
 

--- a/wmm/build.py
+++ b/wmm/build.py
@@ -346,6 +346,8 @@ class wmm_calc():
             #Inputs may only be scalar or vector of consistent size
             if(len(np.unique(sizes))>2):
                 raise ValueError (f'The input position (year,month,day) have different shapes{sizes}. Input dates must have the same shape or 1 (i.e. valid combinations for input lengths are (10,10,10) or (10,10,1))')
+            if(len(np.unique(sizes)) == 2 and np.min(sizes) != 1):
+                raise ValueError (f'The input position (year,month,day) have different shapes{sizes}. Input dates must have the same shape or 1 (i.e. valid combinations for input lengths are (10,10,10) or (10,10,1))')
             #If position has already been set:
             if(year_size != month_size or year_size != day_size or day_size != month_size):
                 
@@ -467,6 +469,12 @@ class wmm_calc():
         # if self.timly_coef_dict == {}:
         if not self.timly_coef_dict:
             self.setup_time()
+
+        # Check the shape before computing
+        sizes = set([len(self.dyear), len(self.theta)])
+
+        if len(sizes) > 1 and 1 not in sizes:
+            raise ValueError(f"Broadcast error: Get time size: {len(self.dyear)}, Get position size: (lat, lon, alt) = {(len(self.lat),len(self.lon),len(self.alt))}. Please input scalars, single array for one parameter or vectors of matching length")
         Bt, Bp, Br = magmath.mag_SPH_summation(self.nmax, self.sph_dict, self.timly_coef_dict["g"],
                                                self.timly_coef_dict["h"], self.Leg, self.theta)
         Bx, By, Bz = magmath.rotate_magvec(Bt, Bp, Br, self.theta, self.lat)


### PR DESCRIPTION
- If users provides year, month and day in array type with different length, it will check whether users provides single array in one parameter and the rest of inputs have same length.
- Check the inputs before computing the magnetic elements
- Added the unit tests to check whether it returns the error to users if it is not able to broadcast the inputs
- Confirmed the package can be built in python 3.14
- Bumped the version from 1.4.3 to 1.4.4